### PR TITLE
Add support for extent param in config.

### DIFF
--- a/public/ui/scripts/dashboard.js
+++ b/public/ui/scripts/dashboard.js
@@ -97,6 +97,7 @@ Dashboard.prototype.setMetrics = function(metrics) {
     .call(self.horizon
       .height(self.options.height)
       .title(function(d) { return d.title; })
+      .extent(function(d) { return d.extent; })
       .metric(function(d) { return self.cube.metric(d.expression); }));
 
    if (this.options.showTotals) {


### PR DESCRIPTION
The extent param is useful in cases where Cubism doesn't get the auto-scaling right.

Example usage: { "title": "Swap %", "expression": "100*sum(collectd(swap).eq(type,'used'))/sum(collectd(swap).in(type,['used','free']))", "extent": [0,100] }

If the extent param is omitted then it will fall back to auto-scaling.
