### PR TITLE
Fixes a bug under FireFox 3.6

### DIFF
--- a/public/ui/scripts/dashboards.js
+++ b/public/ui/scripts/dashboards.js
@@ -20,7 +20,7 @@ DashboardSelect.prototype.setup = function() {
   select.selectedIndex = this.currentIndex;
   select.addEventListener('change', function() {
     window.location = "?dashboard=" + select.value + "&" + location.search.replace(/[?&]dashboard=[^&]*(&|$)/g, "$1").substring(1);
-  });
+  }, false);
 
   document.title = this.getCurrentDashboard().name + ' Dashboard';
 


### PR DESCRIPTION
The last argument to addEventListener() is usually assumed false.  This
happens in most browsers anyway.  Apparently, under FireFox 3.6, the third
argument must be specifically enumerated as false.

I've tested this fix on FireFox 3.6, latest Safari, latest Chrome, and
latest Firefox.  They all seem to work well.

There are two FireFox 3.6 fixes I've sent a pull request for in the cubism.js
source.  This fix should not depend on that fix, however, once they merge
those changes in, cube-dashboard may want to update its cubism vendor source.

FYI: https://github.com/square/cubism/pull/38
