### PR TITLE
Add Heroku support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+.rvmrc
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .rvmrc
 *~
+.env

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node bin/dashboard.js -p $PORT

--- a/README.md
+++ b/README.md
@@ -26,3 +26,9 @@ change the sample-config.json and then run:
 	cube-dashboard config.json
 
 you can also run `cube-dashboard --help` for all the options
+
+To run on Heroku, minify your config.json file and set your configuration in
+the `DASHBOARD_CONFIG` environment variable:
+
+    npm install json-minify
+    heroku config:set DASHBOARD_CONFIG="$(cat config.json | ./node_modules/json-minify/index.js)"

--- a/bin/dashboard.js
+++ b/bin/dashboard.js
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 
 var opt = require('optimist')
-  .usage('Start dashboard server\n$0 <config.json>')
-  .demand(1)
+  .usage('Start dashboard server\n$0 [config.json]\n\nconfig.json can be passed in as local or remote file.\n\nConfig file can also be set by environment variable CUBE_REMOTE_FILE.')
   .options('h', {
     desc: 'Show help info',
     alias: 'help',
@@ -32,6 +31,14 @@ var publicPath = path.join(__dirname, '../public');
 var file = new(static.Server)(publicPath);
 
 var configFile = argv._[0];
+if(typeof(configFile) == 'undefined'){
+  if(typeof(process.env.CUBE_REMOTE_FILE) != 'undefined'){
+    configFile=process.env.CUBE_REMOTE_FILE
+  }else{
+    opt.showHelp();    
+    process.exit();
+  }
+}
 
 var startServer = function(err, configStr) {
   if (err) throw err;

--- a/bin/dashboard.js
+++ b/bin/dashboard.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 var opt = require('optimist')
-  .usage('Start dashboard server\n$0 [config.json]\n\nconfig.json can be passed in as local or remote file.\n\nConfig file can also be set by environment variable CUBE_REMOTE_FILE.')
+  .usage('Start dashboard server\n$0 [config.json]\n\nconfig.json can be passed in as local or remote file.\n\nConfig file can also be set by environment variable CUBE_REMOTE_FILE.\nAlternatively, the JSON configuration can be set in an environment variable, DASHBOARD_CONFIG.')
   .options('h', {
     desc: 'Show help info',
     alias: 'help',
@@ -30,16 +30,6 @@ var fs = require('fs');
 var publicPath = path.join(__dirname, '../public');
 var file = new(static.Server)(publicPath);
 
-var configFile = argv._[0];
-if(typeof(configFile) == 'undefined'){
-  if(typeof(process.env.CUBE_REMOTE_FILE) != 'undefined'){
-    configFile=process.env.CUBE_REMOTE_FILE
-  }else{
-    opt.showHelp();    
-    process.exit();
-  }
-}
-
 var startServer = function(err, configStr) {
   if (err) throw err;
   var config = JSON.parse(configStr);
@@ -62,4 +52,16 @@ var startServer = function(err, configStr) {
   console.log('Server started on port ' + argv.port);
 };
 
-fs.readFile(configFile, 'utf8', startServer);
+var configFile = argv._[0];
+if (typeof(configFile) == 'undefined' && typeof(process.env.CUBE_REMOTE_FILE) != 'undefined') {
+  configFile = process.env.CUBE_REMOTE_FILE;
+}
+
+if (configFile) {
+  fs.readFile(configFile, 'utf8', startServer);
+} else if (typeof(process.env.DASHBOARD_CONFIG) != 'undefined') {
+  startServer(null, process.env.DASHBOARD_CONFIG);
+} else {
+  opt.showHelp();
+  process.exit();
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
   },
   "engines": {
-    "node": "*"
+    "node": "0.6.*"
   },
   "bin": { "cube-dashboard": "./bin/dashboard.js" },
   "keywords": ["cube", "dashboard", "report"]


### PR DESCRIPTION
- Add Procfile (from @trimbletodd)
- Allow config file to be loaded remotely by setting CUBE_REMOTE_FILE environment variable (from @trimbletodd)
- Allow config to read directly from an environment variable, DASHBOARD_CONFIG
- Set a versioned dependency on node for Heroku
