### PR TITLE
Fixes cube-dashboard under node v0.10.x

### DIFF
--- a/bin/dashboard.js
+++ b/bin/dashboard.js
@@ -49,7 +49,7 @@ var startServer = function(err, configStr) {
     } else {
       request.addListener('end', function () {
         file.serve(request, response);
-      });
+      }).resume();
     }
   }).listen(argv.port);
   console.log('Server started on port ' + argv.port);

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "author": "Greg Allen <@jgaui> (http://jga.me)",
   "description": "a dashboard for cube",
   "homepage": "https://github.com/jgallen23/cube-dashboard",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/jgallen23/cube-dashboard.git"
   },
   "dependencies": {
-    "node-static": "0.6.0",
+    "node-static": "0.6.9",
     "optimist": "0.3.4"
   },
   "devDependencies": {


### PR DESCRIPTION
- Adds a new version of node-static to package.json
- Adds .resume() for node v0.10.x streams, also appears to
  work with older versions of node. (tested with v0.8.8)
